### PR TITLE
Adding profile attribute to tab for use in per-profile chrome styling

### DIFF
--- a/build.py
+++ b/build.py
@@ -75,6 +75,7 @@ b.set_var("BASE_DOM_ID",            "multifox-dom")
 
 b.set_var("PROFILE_SESSION",       "multifox-dom-identity-id-session")
 b.set_var("PROFILE_BROWSER_ATTR",  "multifox-dom-identity-id-browser")
+b.set_var("PROFILE_TAB_ATTR",      "multifox-dom-identity-id-tab")
 b.set_var("PROFILE_DISABLED_ATTR", "multifox-dom-identity-id-disabled")
 
 b.set_var("PROFILE_DEPRECATED_DISABLED", "multifox-dom-identity-id-tmp")

--- a/build.py
+++ b/build.py
@@ -75,8 +75,8 @@ b.set_var("BASE_DOM_ID",            "multifox-dom")
 
 b.set_var("PROFILE_SESSION",       "multifox-dom-identity-id-session")
 b.set_var("PROFILE_BROWSER_ATTR",  "multifox-dom-identity-id-browser")
-b.set_var("PROFILE_TAB_ATTR",      "multifox-dom-identity-id-tab")
 b.set_var("PROFILE_DISABLED_ATTR", "multifox-dom-identity-id-disabled")
+b.set_var("PROFILE_TAB_ATTR",      "multifox-id-user-chrome-css")
 
 b.set_var("PROFILE_DEPRECATED_DISABLED", "multifox-dom-identity-id-tmp")
 b.set_var("PROFILE_DEPRECATED_SESSION",  "multifox-dom-identity-id")

--- a/src/modules/main.js
+++ b/src/modules/main.js
@@ -61,6 +61,7 @@ const Profile = {
     // (tab element may not exist when the unload event is raised)
     var sid = id.toString();
     browser.setAttribute("${PROFILE_BROWSER_ATTR}", sid);
+    tab.setAttribute("${PROFILE_TAB_ATTR}", sid);
     Cc["@mozilla.org/browser/sessionstore;1"].
       getService(Ci.nsISessionStore).
         setTabValue(tab, "${PROFILE_SESSION}", sid);
@@ -77,6 +78,7 @@ const Profile = {
   removeIdentity: function(tab) {
     if (tab.linkedBrowser.hasAttribute("${PROFILE_BROWSER_ATTR}")) {
       tab.linkedBrowser.removeAttribute("${PROFILE_BROWSER_ATTR}");
+      tab.linkedBrowser.removeAttribute("${PROFILE_TAB_ATTR}");
 
       var ss = Cc["@mozilla.org/browser/sessionstore;1"].getService(Ci.nsISessionStore);
       ss.setTabValue(tab,    "${PROFILE_SESSION}", ""); // avoid exception

--- a/src/modules/new-window.js
+++ b/src/modules/new-window.js
@@ -253,6 +253,7 @@ function removeState(win) { // uninstalling
   for (var tab of UIUtils.getTabList(win)) {
     // extension is disabled before uninstalling
     tab.linkedBrowser.removeAttribute("${PROFILE_BROWSER_ATTR}");
+    tab.removeAttribute("${PROFILE_TAB_ATTR}");
     ss.setTabValue(tab,    "${PROFILE_SESSION}", ""); // avoid exception
     ss.deleteTabValue(tab, "${PROFILE_SESSION}");
   }


### PR DESCRIPTION
This commit adds the ability to set different tab stylings (different bgcolor, etc) using e.g. user-chrome.css rules, so that per-tab profiles can be easily spotted.

Partially addresses #22.
