### PR TITLE
Add note about container tabs to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 
 Development has stopped due to
 [deprecation of XPCOM extensions](https://blog.mozilla.org/addons/2015/08/21/the-future-of-developing-firefox-add-ons/).
+
+However, Mozilla has implemented a very similar feature in the testing versions of Firefox (a.k.a. Nightly). [Container Tabs](https://wiki.mozilla.org/Security/Contextual_Identity_Project/Containers) are "contextual identities." There is a pre-set and pre-named list of the containers, but they have the same effect as MultiFox, and they officially will work with Firefox (even e10s). Read more details on the Mozilla [blog post](https://blog.mozilla.org/tanvi/2016/06/16/contextual-identities-on-the-web/) or [Mozilla Wiki page](https://wiki.mozilla.org/Security/Contextual_Identity_Project/Containers).


### PR DESCRIPTION
Container tabs are an official feature and direct alternative to Multifox
